### PR TITLE
[ADD] Express engine support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ interface ErynOptions {
 export function compile(filePath : string) : void;
 export function compileDir(dirPath : string, filters : string[]) : void;
 export function compileString(alias : string, str : string) : void;
+export function express(path : string, context : object, callback : (error: any, rendered: string) => void) : void;
 export function render(filePath : string, context : object) : Buffer;
 export function renderString(alias : string, context : object) : Buffer;
 export function setOptions(options : ErynOptions) : void;
@@ -39,6 +40,7 @@ declare const eryn: {
     compile: (filePath : string) => void;
     compileDir: (dirPath : string, filters : string[]) => void;
     compileString: (alias : string, str : string) => void;
+    express(path : string, context : object, callback : (error: any, rendered: string) => void) : void;
     render: (filePath : string, context : object) => Buffer;
     renderString: (alias : string, context : object) => Buffer;
     setOptions: (options : ErynOptions) => void;

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ const eryn = {
 
         binding.compileString(alias, str);
     },
+    express: (path, context, callback) => {
+        try {
+            callback(null, eryn.render(path, context));
+        } catch (error) {
+            callback(error);
+        }
+    },
     render: (path, context) => {
         if(!(path && (typeof path === 'string' && !(path instanceof String))))
             throw `Invalid argument 'path' (expected: string | found: ${typeof(path)})`
@@ -77,6 +84,7 @@ module.exports = {
     compile: eryn.compile,
     compileDir: eryn.compileDir,
     compileString: eryn.compileString,
+    express: eryn.express,
     render: eryn.render,
     renderString: eryn.renderString,
     setOptions: eryn.setOptions,


### PR DESCRIPTION
Use eryn as template engine for express.

Usage example:
```javascript
const eryn = require('eryn');
const app = require('express')();

const workingDirectory = __dirname + '/views';
eryn.setOptions({ workingDirectory });

app.engine('eryn', eryn.express);
app.set('views', workingDirectory);
app.set('view engine', 'eryn');

app.get('/', (request, response) => {
  // render template file from working directory
  response.render('index', { context: { here: 'any value' } });
});
```